### PR TITLE
Add custom HTTP Client for tracing instrumentation

### DIFF
--- a/trace_http_client.go
+++ b/trace_http_client.go
@@ -2,7 +2,6 @@ package ottwirp
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -65,14 +64,7 @@ func (c *TraceHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	// Check for error codes greater than 400, if we have these, then we should
 	// mark the span as an error.
 	if res.StatusCode >= 400 {
-		resCopy := new(http.Response)
-		*resCopy = *res
-		bodyBytes, err := ioutil.ReadAll(resCopy.Body)
-		if err != nil {
-			setErrorSpan(span, err.Error())
-		} else {
-			setErrorSpan(span, string(bodyBytes))
-		}
+		span.SetTag("error", true)
 	}
 
 	// We want to track when the body is closed, meaning the server is done with

--- a/trace_http_client.go
+++ b/trace_http_client.go
@@ -65,7 +65,9 @@ func (c *TraceHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	// Check for error codes greater than 400, if we have these, then we should
 	// mark the span as an error.
 	if res.StatusCode >= 400 {
-		bodyBytes, err := ioutil.ReadAll(res.Body)
+		resCopy := new(http.Response)
+		*resCopy = *res
+		bodyBytes, err := ioutil.ReadAll(resCopy.Body)
 		if err != nil {
 			setErrorSpan(span, err.Error())
 		} else {

--- a/trace_http_client.go
+++ b/trace_http_client.go
@@ -25,12 +25,9 @@ func NewTraceHTTPClient(client *http.Client, tracer opentracing.Tracer) *TraceHT
 
 func (c *TraceHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
-	// Check for a parent span context
-	// Then create a span as a child of if the span parent span is not nil
-	// SetOperationName to whatever is injected
 	methodName, ok := twirp.MethodName(ctx)
 	if !ok {
-		methodName = req.URL.String()
+		methodName = req.URL.Path
 	}
 	span, ctx := opentracing.StartSpanFromContext(ctx, methodName, ext.SpanKindRPCClient)
 	ext.HTTPMethod.Set(span, req.Method)

--- a/trace_http_client.go
+++ b/trace_http_client.go
@@ -66,9 +66,9 @@ func (c *TraceHTTPClient) Do(req *http.Request) (*http.Response, error) {
 		bodyBytes, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			setErrorSpan(span, err.Error())
+		} else {
+			setErrorSpan(span, string(bodyBytes))
 		}
-
-		setErrorSpan(span, string(bodyBytes))
 	}
 
 	// We want to track when the body is closed, meaning the server is done with

--- a/trace_http_client.go
+++ b/trace_http_client.go
@@ -10,14 +10,19 @@ import (
 	"github.com/twitchtv/twirp"
 )
 
+// Doer as the interface used to "Do" HTTP requests.
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // TraceHTTPClient wraps a provided http.Client and tracer for instrumenting
 // requests.
 type TraceHTTPClient struct {
-	client *http.Client
+	client Doer
 	tracer opentracing.Tracer
 }
 
-func NewTraceHTTPClient(client *http.Client, tracer opentracing.Tracer) *TraceHTTPClient {
+func NewTraceHTTPClient(client Doer, tracer opentracing.Tracer) Doer {
 	return &TraceHTTPClient{
 		client: client,
 		tracer: tracer,

--- a/trace_http_client.go
+++ b/trace_http_client.go
@@ -54,16 +54,16 @@ func (c *TraceHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	ext.HTTPStatusCode.Set(span, uint16(res.StatusCode))
 
 	// We want to finish recording metrics once the body is read.
-	res.Body = closeTracker{res.Body, span}
+	res.Body = closer{res.Body, span}
 	return res, nil
 }
 
-type closeTracker struct {
+type closer struct {
 	io.ReadCloser
 	sp opentracing.Span
 }
 
-func (c closeTracker) Close() error {
+func (c closer) Close() error {
 	err := c.ReadCloser.Close()
 	c.sp.Finish()
 	return err

--- a/trace_http_client.go
+++ b/trace_http_client.go
@@ -23,7 +23,9 @@ type TraceHTTPClient struct {
 	tracer opentracing.Tracer
 }
 
-func NewTraceHTTPClient(client HTTPClient, tracer opentracing.Tracer) HTTPClient {
+var _ HTTPClient = (*TraceHTTPClient)(nil)
+
+func NewTraceHTTPClient(client HTTPClient, tracer opentracing.Tracer) *TraceHTTPClient {
 	return &TraceHTTPClient{
 		client: client,
 		tracer: tracer,

--- a/trace_http_client.go
+++ b/trace_http_client.go
@@ -40,6 +40,10 @@ func (c *TraceHTTPClient) Do(req *http.Request) (*http.Response, error) {
 		opentracing.HTTPHeaders,
 		opentracing.HTTPHeadersCarrier(req.Header),
 	)
+	if err != nil {
+		span.LogFields(otlog.String("event", "tracer.Inject() failed"), otlog.Error(err))
+	}
+
 	req = req.WithContext(ctx)
 
 	res, err := c.client.Do(req)

--- a/trace_http_client.go
+++ b/trace_http_client.go
@@ -75,18 +75,21 @@ func (c *TraceHTTPClient) Do(req *http.Request) (*http.Response, error) {
 
 	// We want to track when the body is closed, meaning the server is done with
 	// the response.
-	res.Body = closer{res.Body, span}
+	res.Body = closer{
+		ReadCloser: res.Body,
+		span:       span,
+	}
 	return res, nil
 }
 
 type closer struct {
 	io.ReadCloser
-	sp opentracing.Span
+	span opentracing.Span
 }
 
 func (c closer) Close() error {
 	err := c.ReadCloser.Close()
-	c.sp.Finish()
+	c.span.Finish()
 	return err
 }
 

--- a/trace_http_client.go
+++ b/trace_http_client.go
@@ -10,6 +10,8 @@ import (
 	"github.com/twitchtv/twirp"
 )
 
+// TraceHTTPClient wraps a provided http.Client and tracer for instrumenting
+// requests.
 type TraceHTTPClient struct {
 	client *http.Client
 	tracer opentracing.Tracer

--- a/trace_http_client.go
+++ b/trace_http_client.go
@@ -16,19 +16,19 @@ type TraceHTTPClient struct {
 }
 
 func NewTraceHTTPClient(client *http.Client, tracer opentracing.Tracer) *TraceHTTPClient {
-	// Perhaps get the global tracer here?
 	return &TraceHTTPClient{
 		client: client,
 		tracer: tracer,
 	}
 }
 
-// Do makes the HTTP request with the tracing headers injected into the request
-// and into the tracer itself.
+// Do injects the tracing headers into the tracer and updates the headers before
+// making the actual request.
 func (c *TraceHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 	methodName, ok := twirp.MethodName(ctx)
 	if !ok {
+		// No method name, let's use the URL path instead then.
 		methodName = req.URL.Path
 	}
 	span, ctx := opentracing.StartSpanFromContext(ctx, methodName, ext.SpanKindRPCClient)

--- a/trace_http_client.go
+++ b/trace_http_client.go
@@ -11,19 +11,19 @@ import (
 	"github.com/twitchtv/twirp"
 )
 
-// Doer as the interface used to "Do" HTTP requests.
-type Doer interface {
+// HTTPClient as an interface that models *http.Client.
+type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
 // TraceHTTPClient wraps a provided http.Client and tracer for instrumenting
 // requests.
 type TraceHTTPClient struct {
-	client Doer
+	client HTTPClient
 	tracer opentracing.Tracer
 }
 
-func NewTraceHTTPClient(client Doer, tracer opentracing.Tracer) Doer {
+func NewTraceHTTPClient(client HTTPClient, tracer opentracing.Tracer) HTTPClient {
 	return &TraceHTTPClient{
 		client: client,
 		tracer: tracer,

--- a/trace_http_client.go
+++ b/trace_http_client.go
@@ -1,0 +1,69 @@
+package ottwirp
+
+import (
+	"io"
+	"net/http"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/twitchtv/twirp"
+)
+
+type TraceHTTPClient struct {
+	client *http.Client
+	tracer opentracing.Tracer
+}
+
+func NewTraceHTTPClient(client *http.Client, tracer opentracing.Tracer) *TraceHTTPClient {
+	// Perhaps get the global tracer here?
+	return &TraceHTTPClient{
+		client: client,
+		tracer: tracer,
+	}
+}
+
+func (c *TraceHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+	// Check for a parent span context
+	// Then create a span as a child of if the span parent span is not nil
+	// SetOperationName to whatever is injected
+	methodName, ok := twirp.MethodName(ctx)
+	if !ok {
+		methodName = req.URL.String()
+	}
+	span, ctx := opentracing.StartSpanFromContext(ctx, methodName, ext.SpanKindRPCClient)
+	ext.HTTPMethod.Set(span, req.Method)
+	ext.HTTPUrl.Set(span, req.URL.String())
+
+	err := c.tracer.Inject(span.Context(),
+		opentracing.HTTPHeaders,
+		opentracing.HTTPHeadersCarrier(req.Header),
+	)
+	req = req.WithContext(ctx)
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		span.SetTag("error", true)
+		span.LogFields(otlog.String("event", "error"), otlog.String("message", err.Error()))
+		span.Finish()
+		return res, err
+	}
+	// Set the HTTP status code from the service.
+	ext.HTTPStatusCode.Set(span, uint16(res.StatusCode))
+
+	// We want to finish recording metrics once the body is read.
+	res.Body = closeTracker{res.Body, span}
+	return res, nil
+}
+
+type closeTracker struct {
+	io.ReadCloser
+	sp opentracing.Span
+}
+
+func (c closeTracker) Close() error {
+	err := c.ReadCloser.Close()
+	c.sp.Finish()
+	return err
+}

--- a/trace_http_client_test.go
+++ b/trace_http_client_test.go
@@ -1,0 +1,45 @@
+package ottwirp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/iheanyi/twirptest"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/stretchr/testify/assert"
+	"github.com/twitchtv/twirp"
+)
+
+func TestTraceHTTPClient(t *testing.T) {
+	tracer := setupMockTracer()
+	hooks := NewOpenTracingHooks(tracer)
+	server, client := TraceServerAndTraceClient(twirptest.NoopHatmaker(), hooks, tracer)
+	defer server.Close()
+
+	_, err := client.MakeHat(context.Background(), &twirptest.Size{})
+	if err != nil {
+		t.Fatalf("twirptest client err=%q", err)
+	}
+	clientSpan := tracer.FinishedSpans()[1]
+	serverSpan := tracer.FinishedSpans()[0]
+	expectedTags := map[string]interface{}{
+		"span.kind":        ext.SpanKindEnum("client"),
+		"http.status_code": uint16(200),
+		"http.url":         fmt.Sprintf("%s/twirp/twirptest.Haberdasher/MakeHat", server.URL),
+		"http.method":      "POST",
+	}
+	assert.Equal(t, clientSpan.OperationName, "MakeHat", "expected operation name to be MakeHat")
+	assert.Equal(t, expectedTags, clientSpan.Tags(), "expected tags to match")
+	assert.Equal(t, serverSpan.SpanContext.TraceID, clientSpan.SpanContext.TraceID, "expected trace to propagate properly")
+	assert.Equal(t, serverSpan.ParentID, clientSpan.SpanContext.SpanID, "expected span to propagate properly")
+}
+
+func TraceServerAndTraceClient(h twirptest.Haberdasher, hooks *twirp.ServerHooks, tracer opentracing.Tracer) (*httptest.Server, twirptest.Haberdasher) {
+	s := httptest.NewServer(WithTraceContext(twirptest.NewHaberdasherServer(h, hooks), tracer))
+	c := twirptest.NewHaberdasherProtobufClient(s.URL, NewTraceHTTPClient(http.DefaultClient, tracer))
+	return s, c
+}

--- a/trace_http_client_test.go
+++ b/trace_http_client_test.go
@@ -10,32 +10,55 @@ import (
 	"github.com/iheanyi/twirptest"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 	"github.com/twitchtv/twirp"
 )
 
 func TestTraceHTTPClient(t *testing.T) {
-	tracer := setupMockTracer()
-	hooks := NewOpenTracingHooks(tracer)
-	server, client := TraceServerAndTraceClient(twirptest.NoopHatmaker(), hooks, tracer)
-	defer server.Close()
+	tests := []struct {
+		desc         string
+		errExpected  bool
+		service      twirptest.Haberdasher
+		expectedTags func(*httptest.Server) map[string]interface{}
+		expectedLogs []mocktracer.MockLogRecord
+	}{
+		{
+			desc:        "properly traces valid requests",
+			errExpected: false,
+			service:     twirptest.NoopHatmaker(),
+			expectedTags: func(server *httptest.Server) map[string]interface{} {
+				return map[string]interface{}{
+					"span.kind":        ext.SpanKindEnum("client"),
+					"http.status_code": uint16(200),
+					"http.url":         fmt.Sprintf("%s/twirp/twirptest.Haberdasher/MakeHat", server.URL),
+					"http.method":      "POST",
+				}
+			},
+		},
+	}
 
-	_, err := client.MakeHat(context.Background(), &twirptest.Size{})
-	if err != nil {
-		t.Fatalf("twirptest client err=%q", err)
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			tracer := setupMockTracer()
+			hooks := NewOpenTracingHooks(tracer)
+			server, client := TraceServerAndTraceClient(tt.service, hooks, tracer)
+			defer server.Close()
+
+			_, err := client.MakeHat(context.Background(), &twirptest.Size{})
+			if err != nil {
+				if !tt.errExpected {
+					t.Fatalf("twirptest client err=%q", err)
+				}
+			}
+			clientSpan := tracer.FinishedSpans()[1]
+			serverSpan := tracer.FinishedSpans()[0]
+			assert.Equal(t, clientSpan.OperationName, "MakeHat", "expected operation name to be MakeHat")
+			assert.Equal(t, tt.expectedTags(server), clientSpan.Tags(), "expected tags to match")
+			assert.Equal(t, serverSpan.SpanContext.TraceID, clientSpan.SpanContext.TraceID, "expected trace to propagate properly")
+			assert.Equal(t, serverSpan.ParentID, clientSpan.SpanContext.SpanID, "expected span to propagate properly")
+		})
 	}
-	clientSpan := tracer.FinishedSpans()[1]
-	serverSpan := tracer.FinishedSpans()[0]
-	expectedTags := map[string]interface{}{
-		"span.kind":        ext.SpanKindEnum("client"),
-		"http.status_code": uint16(200),
-		"http.url":         fmt.Sprintf("%s/twirp/twirptest.Haberdasher/MakeHat", server.URL),
-		"http.method":      "POST",
-	}
-	assert.Equal(t, clientSpan.OperationName, "MakeHat", "expected operation name to be MakeHat")
-	assert.Equal(t, expectedTags, clientSpan.Tags(), "expected tags to match")
-	assert.Equal(t, serverSpan.SpanContext.TraceID, clientSpan.SpanContext.TraceID, "expected trace to propagate properly")
-	assert.Equal(t, serverSpan.ParentID, clientSpan.SpanContext.SpanID, "expected span to propagate properly")
 }
 
 func TraceServerAndTraceClient(h twirptest.Haberdasher, hooks *twirp.ServerHooks, tracer opentracing.Tracer) (*httptest.Server, twirptest.Haberdasher) {

--- a/trace_http_client_test.go
+++ b/trace_http_client_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/iheanyi/twirptest"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
-	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 	"github.com/twitchtv/twirp"
 )
@@ -21,7 +20,6 @@ func TestTraceHTTPClient(t *testing.T) {
 		errExpected  bool
 		service      twirptest.Haberdasher
 		expectedTags func(*httptest.Server) map[string]interface{}
-		expectedLogs []mocktracer.MockLogRecord
 	}{
 		{
 			desc:        "properly traces valid requests",

--- a/trace_http_client_test.go
+++ b/trace_http_client_test.go
@@ -6,13 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 
 	"github.com/iheanyi/twirptest"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
-	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 	"github.com/twitchtv/twirp"
 )
@@ -23,7 +21,6 @@ func TestTraceHTTPClient(t *testing.T) {
 		errExpected  bool
 		service      twirptest.Haberdasher
 		expectedTags func(*httptest.Server) map[string]interface{}
-		expectedLogs []mocktracer.MockLogRecord
 	}{
 		{
 			desc:        "properly traces valid requests",
@@ -50,17 +47,6 @@ func TestTraceHTTPClient(t *testing.T) {
 					"http.url":         fmt.Sprintf("%s/twirp/twirptest.Haberdasher/MakeHat", server.URL),
 					"http.method":      "POST",
 				}
-			},
-			expectedLogs: []mocktracer.MockLogRecord{
-				{
-					Fields: []mocktracer.MockKeyValue{
-						{
-							Key:         "event",
-							ValueKind:   reflect.String,
-							ValueString: "error",
-						},
-					},
-				},
 			},
 		},
 	}

--- a/trace_http_client_test.go
+++ b/trace_http_client_test.go
@@ -59,11 +59,6 @@ func TestTraceHTTPClient(t *testing.T) {
 							ValueKind:   reflect.String,
 							ValueString: "error",
 						},
-						{
-							Key:         "message",
-							ValueKind:   reflect.String,
-							ValueString: "test",
-						},
 					},
 				},
 			},

--- a/trace_http_client_test.go
+++ b/trace_http_client_test.go
@@ -81,6 +81,8 @@ func TestTraceHTTPClient(t *testing.T) {
 			if err != nil {
 				if !tt.errExpected {
 					t.Fatalf("twirptest client err=%q", err)
+				} else {
+					assert.Error(t, err, "expected an error")
 				}
 			}
 			clientSpan := tracer.FinishedSpans()[1]

--- a/tracing.go
+++ b/tracing.go
@@ -101,30 +101,6 @@ func NewOpenTracingHooks(tracer ot.Tracer) *twirp.ServerHooks {
 	return hooks
 }
 
-// InjectClientSpan is used for injecting the SpanContext into the request
-// headers.
-func InjectClientSpan(ctx context.Context, span ot.Span) (context.Context, error) {
-	header, ok := twirp.HTTPRequestHeaders(ctx)
-	if !ok {
-		header = http.Header{}
-	}
-
-	tracer := ot.GlobalTracer()
-	err := tracer.Inject(span.Context(),
-		ot.HTTPHeaders,
-		ot.HTTPHeadersCarrier(header),
-	)
-	if err != nil {
-		span.LogFields(otlog.String("event", "tracer.Inject() failed"), otlog.Error(err))
-	}
-
-	if !ok {
-		return twirp.WithHTTPRequestHeaders(ctx, header)
-	}
-
-	return ctx, nil
-}
-
 // WithTraceContext wraps the handler and extracts the span context from request
 // headers to attach to the context for connecting client and server calls.
 func WithTraceContext(base http.Handler, tracer ot.Tracer) http.Handler {

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -3,7 +3,6 @@ package ottwirp
 import (
 	"context"
 	"errors"
-	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/iheanyi/twirptest"
 	opentracing "github.com/opentracing/opentracing-go"
-	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
@@ -95,48 +93,8 @@ func TestTracingHooks(t *testing.T) {
 	}
 }
 
-func TestClientSpanInjection(t *testing.T) {
-	tracer := setupMockTracer()
-	hooks := NewOpenTracingHooks(tracer)
-
-	server, client := TraceServerAndClient(twirptest.NoopHatmaker(), hooks, tracer)
-	defer server.Close()
-
-	span, ctx := ot.StartSpanFromContext(context.Background(), "TestClientSpanInjection", ext.SpanKindRPCClient)
-	ctx, err := InjectClientSpan(ctx, span)
-	if err != nil {
-		t.Fatalf("error injecting span, err=%q", err)
-	}
-
-	// Check Trace Headers
-	header, _ := twirp.HTTPRequestHeaders(ctx)
-	assert.Regexp(t, "\\d+", header["Mockpfx-Ids-Spanid"], "Mockpfx-Ids-Spanid")
-	assert.Regexp(t, "\\d+", header["Mockpfx-Ids-Traceid"], "Mockpfx-Ids-Traceid")
-	assert.Equal(t, []string{"true"}, header["Mockpfx-Ids-Sampled"], "Mockpfx-Ids-Sampled")
-
-	_, err = client.MakeHat(ctx, &twirptest.Size{})
-	if err != nil {
-		t.Fatalf("twirptest client err=%q", err)
-	}
-	span.Finish()
-	clientSpan := tracer.FinishedSpans()[1]
-	serverSpan := tracer.FinishedSpans()[0]
-	expectedTags := map[string]interface{}{
-		"span.kind": ext.SpanKindEnum("client"),
-	}
-	assert.Equal(t, expectedTags, clientSpan.Tags(), "expected tags to match")
-	assert.Equal(t, serverSpan.SpanContext.TraceID, clientSpan.SpanContext.TraceID, "expected trace to propagate properly")
-	assert.Equal(t, serverSpan.ParentID, clientSpan.SpanContext.SpanID, "expected span to propagate properly")
-}
-
 func serverAndClient(h twirptest.Haberdasher, hooks *twirp.ServerHooks) (*httptest.Server, twirptest.Haberdasher) {
 	return twirptest.ServerAndClient(h, hooks)
-}
-
-func TraceServerAndClient(h twirptest.Haberdasher, hooks *twirp.ServerHooks, tracer opentracing.Tracer) (*httptest.Server, twirptest.Haberdasher) {
-	s := httptest.NewServer(WithTraceContext(twirptest.NewHaberdasherServer(h, hooks), tracer))
-	c := twirptest.NewHaberdasherProtobufClient(s.URL, http.DefaultClient)
-	return s, c
 }
 
 func setupMockTracer() *mocktracer.MockTracer {


### PR DESCRIPTION
This pull request introduces the use of a custom HTTP client for tracing rather than relying on a helper method for client span injection. This makes getting started with tracing on the client-side way more DRY. 