### PR TITLE
Add options for client and server tracing to skip client errs

### DIFF
--- a/trace_http_client.go
+++ b/trace_http_client.go
@@ -20,7 +20,7 @@ type HTTPClient interface {
 type TraceHTTPClient struct {
 	client HTTPClient
 	tracer opentracing.Tracer
-	opts *ClientOptions
+	opts   *ClientOptions
 }
 
 // ClientOptions is a struct containing tracing client configuration options. Options are exposed as functional options
@@ -58,7 +58,7 @@ func NewTraceHTTPClient(client HTTPClient, tracer opentracing.Tracer, opts ...Cl
 	return &TraceHTTPClient{
 		client: client,
 		tracer: tracer,
-		opts: clientOpts,
+		opts:   clientOpts,
 	}
 }
 

--- a/trace_http_client_test.go
+++ b/trace_http_client_test.go
@@ -20,7 +20,7 @@ func TestTraceHTTPClient(t *testing.T) {
 		desc         string
 		errExpected  bool
 		service      twirptest.Haberdasher
-		clientOpts   []ClientOpt
+		clientOpts   []ClientOption
 		expectedTags func(*httptest.Server) map[string]interface{}
 	}{
 		{
@@ -54,7 +54,7 @@ func TestTraceHTTPClient(t *testing.T) {
 			desc:        "does not report client errors in span if correct option is set",
 			errExpected: true,
 			service:     twirptest.ErroringHatmaker(twirp.NotFoundError("not found")),
-			clientOpts: []ClientOpt{WithClientUserErr(false)},
+			clientOpts: []ClientOption{IncludeUserErrors(false)},
 			expectedTags: func(server *httptest.Server) map[string]interface{} {
 				return map[string]interface{}{
 					"span.kind":        ext.SpanKindEnum("client"),
@@ -91,7 +91,7 @@ func TestTraceHTTPClient(t *testing.T) {
 	}
 }
 
-func TraceServerAndTraceClient(h twirptest.Haberdasher, hooks *twirp.ServerHooks, tracer opentracing.Tracer, opts ...ClientOpt) (*httptest.Server, twirptest.Haberdasher) {
+func TraceServerAndTraceClient(h twirptest.Haberdasher, hooks *twirp.ServerHooks, tracer opentracing.Tracer, opts ...ClientOption) (*httptest.Server, twirptest.Haberdasher) {
 	s := httptest.NewServer(WithTraceContext(twirptest.NewHaberdasherServer(h, hooks), tracer))
 	c := twirptest.NewHaberdasherProtobufClient(s.URL, NewTraceHTTPClient(http.DefaultClient, tracer, opts...))
 	return s, c

--- a/trace_http_client_test.go
+++ b/trace_http_client_test.go
@@ -20,6 +20,7 @@ func TestTraceHTTPClient(t *testing.T) {
 		desc         string
 		errExpected  bool
 		service      twirptest.Haberdasher
+		clientOpts   []ClientOpt
 		expectedTags func(*httptest.Server) map[string]interface{}
 	}{
 		{
@@ -49,13 +50,27 @@ func TestTraceHTTPClient(t *testing.T) {
 				}
 			},
 		},
+		{
+			desc:        "does not report client errors in span if correct option is set",
+			errExpected: true,
+			service:     twirptest.ErroringHatmaker(twirp.NotFoundError("not found")),
+			clientOpts: []ClientOpt{WithClientUserErr(false)},
+			expectedTags: func(server *httptest.Server) map[string]interface{} {
+				return map[string]interface{}{
+					"span.kind":        ext.SpanKindEnum("client"),
+					"http.status_code": uint16(404),
+					"http.url":         fmt.Sprintf("%s/twirp/twirptest.Haberdasher/MakeHat", server.URL),
+					"http.method":      "POST",
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			tracer := setupMockTracer()
 			hooks := NewOpenTracingHooks(tracer)
-			server, client := TraceServerAndTraceClient(tt.service, hooks, tracer)
+			server, client := TraceServerAndTraceClient(tt.service, hooks, tracer, tt.clientOpts...)
 			defer server.Close()
 
 			_, err := client.MakeHat(context.Background(), &twirptest.Size{})
@@ -76,8 +91,8 @@ func TestTraceHTTPClient(t *testing.T) {
 	}
 }
 
-func TraceServerAndTraceClient(h twirptest.Haberdasher, hooks *twirp.ServerHooks, tracer opentracing.Tracer) (*httptest.Server, twirptest.Haberdasher) {
+func TraceServerAndTraceClient(h twirptest.Haberdasher, hooks *twirp.ServerHooks, tracer opentracing.Tracer, opts ...ClientOpt) (*httptest.Server, twirptest.Haberdasher) {
 	s := httptest.NewServer(WithTraceContext(twirptest.NewHaberdasherServer(h, hooks), tracer))
-	c := twirptest.NewHaberdasherProtobufClient(s.URL, NewTraceHTTPClient(http.DefaultClient, tracer))
+	c := twirptest.NewHaberdasherProtobufClient(s.URL, NewTraceHTTPClient(http.DefaultClient, tracer, opts...))
 	return s, c
 }

--- a/trace_http_client_test.go
+++ b/trace_http_client_test.go
@@ -20,7 +20,7 @@ func TestTraceHTTPClient(t *testing.T) {
 		desc         string
 		errExpected  bool
 		service      twirptest.Haberdasher
-		clientOpts   []ClientOption
+		clientOpts   []TraceOption
 		expectedTags func(*httptest.Server) map[string]interface{}
 	}{
 		{
@@ -54,7 +54,7 @@ func TestTraceHTTPClient(t *testing.T) {
 			desc:        "does not report client errors in span if correct option is set",
 			errExpected: true,
 			service:     twirptest.ErroringHatmaker(twirp.NotFoundError("not found")),
-			clientOpts:  []ClientOption{IncludeUserErrors(false)},
+			clientOpts:  []TraceOption{IncludeClientErrors(false)},
 			expectedTags: func(server *httptest.Server) map[string]interface{} {
 				return map[string]interface{}{
 					"span.kind":        ext.SpanKindEnum("client"),
@@ -91,7 +91,7 @@ func TestTraceHTTPClient(t *testing.T) {
 	}
 }
 
-func TraceServerAndTraceClient(h twirptest.Haberdasher, hooks *twirp.ServerHooks, tracer opentracing.Tracer, opts ...ClientOption) (*httptest.Server, twirptest.Haberdasher) {
+func TraceServerAndTraceClient(h twirptest.Haberdasher, hooks *twirp.ServerHooks, tracer opentracing.Tracer, opts ...TraceOption) (*httptest.Server, twirptest.Haberdasher) {
 	s := httptest.NewServer(WithTraceContext(twirptest.NewHaberdasherServer(h, hooks), tracer))
 	c := twirptest.NewHaberdasherProtobufClient(s.URL, NewTraceHTTPClient(http.DefaultClient, tracer, opts...))
 	return s, c

--- a/trace_http_client_test.go
+++ b/trace_http_client_test.go
@@ -54,7 +54,7 @@ func TestTraceHTTPClient(t *testing.T) {
 			desc:        "does not report client errors in span if correct option is set",
 			errExpected: true,
 			service:     twirptest.ErroringHatmaker(twirp.NotFoundError("not found")),
-			clientOpts: []ClientOption{IncludeUserErrors(false)},
+			clientOpts:  []ClientOption{IncludeUserErrors(false)},
 			expectedTags: func(server *httptest.Server) map[string]interface{} {
 				return map[string]interface{}{
 					"span.kind":        ext.SpanKindEnum("client"),

--- a/tracing.go
+++ b/tracing.go
@@ -22,27 +22,27 @@ type tracingInfoKey struct{}
 
 type TraceServerHooks struct {
 	Tracer ot.Tracer
-	opts   *TraceServerOptions
+	opts   *TraceOptions
 }
 
-type TraceServerOptions struct {
+type TraceOptions struct {
 	includeClientErrors bool
 }
 
-type TraceServerOption func(serverOpts *TraceServerOptions)
+type TraceOption func(opts *TraceOptions)
 
 // IncludeClientErrors, if set, will report client errors (4xx) as errors in the server span.
 // If not set, only 5xx status will be reported as erroneous.
-func IncludeClientErrors(includeClientErrors bool) TraceServerOption {
-	return func(serverOpts *TraceServerOptions) {
-		serverOpts.includeClientErrors = includeClientErrors
+func IncludeClientErrors(includeClientErrors bool) TraceOption {
+	return func(opts *TraceOptions) {
+		opts.includeClientErrors = includeClientErrors
 	}
 }
 
 // NewOpenTracingHooks provides a twirp.ServerHooks struct which records
 // OpenTracing spans.
-func NewOpenTracingHooks(tracer ot.Tracer, opts ...TraceServerOption) *twirp.ServerHooks {
-	serverOpts := &TraceServerOptions{
+func NewOpenTracingHooks(tracer ot.Tracer, opts ...TraceOption) *twirp.ServerHooks {
+	serverOpts := &TraceOptions{
 		includeClientErrors: true,
 	}
 

--- a/tracing.go
+++ b/tracing.go
@@ -20,62 +20,80 @@ type tracingInfoKey struct{}
 // TODO: Add functional options for things such as filtering or maybe logging
 // custom fields?
 
+type TraceServerHooks struct {
+	Tracer ot.Tracer
+	opts   *TraceServerOptions
+}
+
+type TraceServerOptions struct {
+	includeClientErrors bool
+}
+
+type TraceServerOption func(serverOpts *TraceServerOptions)
+
+// IncludeClientErrors, if set, will report client errors (4xx) as errors in the server span.
+// If not set, only 5xx status will be reported as erroneous.
+func IncludeClientErrors(includeClientErrors bool) TraceServerOption {
+	return func(serverOpts *TraceServerOptions) {
+		serverOpts.includeClientErrors = includeClientErrors
+	}
+}
+
 // NewOpenTracingHooks provides a twirp.ServerHooks struct which records
 // OpenTracing spans.
-func NewOpenTracingHooks(tracer ot.Tracer, opts ...HookOpt) *twirp.ServerHooks {
-	hooks := &twirp.ServerHooks{
-		RequestReceived: startTraceSpan(tracer),
-		RequestRouted:   handleRequestRouted,
-		ResponseSent:    finishTrace,
-		Error:           handleError(true),
+func NewOpenTracingHooks(tracer ot.Tracer, opts ...TraceServerOption) *twirp.ServerHooks {
+	serverOpts := &TraceServerOptions{
+		includeClientErrors: true,
 	}
 
 	for _, opt := range opts {
-		opt(hooks)
+		opt(serverOpts)
 	}
 
-	return hooks
+	traceHooks := &TraceServerHooks{
+		Tracer: tracer,
+		opts:   serverOpts,
+	}
+
+	return traceHooks.TwirpHooks()
 }
 
-type HookOpt func(h *twirp.ServerHooks)
-
-// WithUserErr, if set, will report client errors (4xx) as errors in the server span.
-// If not set, only 5xx status will be reported as erroneous.
-func WithUserErr(withUserError bool) HookOpt {
-	return func(h *twirp.ServerHooks) {
-		h.Error = handleError(withUserError)
+func (t *TraceServerHooks) TwirpHooks() *twirp.ServerHooks {
+	return &twirp.ServerHooks{
+		RequestReceived: t.startTraceSpan,
+		RequestRouted:   t.handleRequestRouted,
+		ResponseSent:    t.finishTrace,
+		Error:           t.handleError,
 	}
 }
 
-func startTraceSpan(tracer ot.Tracer) func(context.Context) (context.Context, error) {
-	return func(ctx context.Context) (context.Context, error) {
-		spanContext, err := extractSpanCtx(ctx, tracer)
-		if err != nil && err != ot.ErrSpanContextNotFound { // nolint: megacheck, staticcheck
-			// TODO: We need to do error reporting here. The tracer implementation
-			// will have to do something because we don't know where this error will
-			// live.
-		}
-		// Create the initial span, it won't have a method name just yet.
-		span, ctx := ot.StartSpanFromContext(ctx, RequestReceivedEvent, ext.RPCServerOption(spanContext), ext.SpanKindRPCServer)
-		if span != nil {
-			span.SetTag("component", "twirp")
-
-			if packageName, ok := twirp.PackageName(ctx); ok {
-				span.SetTag("package", packageName)
-			}
-
-			if serviceName, ok := twirp.ServiceName(ctx); ok {
-				span.SetTag("service", serviceName)
-			}
-		}
-
-		return ctx, nil
+func (t *TraceServerHooks) startTraceSpan(ctx context.Context) (context.Context, error) {
+	spanContext, err := extractSpanCtx(ctx, t.Tracer)
+	if err != nil && err != ot.ErrSpanContextNotFound { // nolint: megacheck, staticcheck
+		// TODO: We need to do error reporting here. The tracer implementation
+		// will have to do something because we don't know where this error will
+		// live.
 	}
+	// Create the initial span, it won't have a method name just yet.
+	span, ctx := ot.StartSpanFromContext(ctx, RequestReceivedEvent, ext.RPCServerOption(spanContext), ext.SpanKindRPCServer)
+	if span != nil {
+		span.SetTag("component", "twirp")
+
+		if packageName, ok := twirp.PackageName(ctx); ok {
+			span.SetTag("package", packageName)
+		}
+
+		if serviceName, ok := twirp.ServiceName(ctx); ok {
+			span.SetTag("service", serviceName)
+		}
+	}
+
+	return ctx, nil
 }
 
 // handleRequestRouted sets the operation name because we won't know what it is
 // until the RequestRouted hook.
-func handleRequestRouted(ctx context.Context) (context.Context, error) {
+func (t *TraceServerHooks) handleRequestRouted(ctx context.Context) (context.Context, error) {
 	span := ot.SpanFromContext(ctx)
 	if span != nil {
 		if method, ok := twirp.MethodName(ctx); ok {
@@ -86,7 +104,7 @@ func handleRequestRouted(ctx context.Context) (context.Context, error) {
 	return ctx, nil
 }
 
-func finishTrace(ctx context.Context) {
+func (t *TraceServerHooks) finishTrace(ctx context.Context) {
 	span := ot.SpanFromContext(ctx)
 	if span != nil {
 		status, haveStatus := twirp.StatusCode(ctx)
@@ -101,6 +119,19 @@ func finishTrace(ctx context.Context) {
 	}
 }
 
+func (t *TraceServerHooks) handleError(ctx context.Context, err twirp.Error) context.Context {
+	span := ot.SpanFromContext(ctx)
+	statusCode := twirp.ServerHTTPStatusFromErrorCode(err.Code())
+	if span != nil {
+		if t.opts.includeClientErrors || statusCode >= 500 {
+			span.SetTag("error", true)
+		}
+		span.LogFields(otlog.String("event", "error"), otlog.String("message", err.Msg()))
+	}
+
+	return ctx
+}
+
 // WithTraceContext wraps the handler and extracts the span context from request
 // headers to attach to the context for connecting client and server calls.
 func WithTraceContext(base http.Handler, tracer ot.Tracer) http.Handler {
@@ -112,21 +143,6 @@ func WithTraceContext(base http.Handler, tracer ot.Tracer) http.Handler {
 
 		base.ServeHTTP(w, r)
 	})
-}
-
-func handleError(withUserErr bool) func(ctx context.Context, err twirp.Error) context.Context {
-	return func(ctx context.Context, err twirp.Error) context.Context {
-		span := ot.SpanFromContext(ctx)
-		statusCode := twirp.ServerHTTPStatusFromErrorCode(err.Code())
-		if span != nil {
-			if withUserErr || statusCode >= 500 {
-				span.SetTag("error", true)
-			}
-			span.LogFields(otlog.String("event", "error"), otlog.String("message", err.Msg()))
-		}
-
-		return ctx
-	}
 }
 
 func extractSpanCtx(ctx context.Context, tracer ot.Tracer) (ot.SpanContext, error) {

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -21,7 +21,7 @@ func TestTracingHooks(t *testing.T) {
 	tests := []struct {
 		desc         string
 		service      twirptest.Haberdasher
-		hookOpts     []HookOpt
+		serverOpts   []TraceServerOption
 		expectedTags map[string]interface{}
 		expectedLogs []mocktracer.MockLogRecord
 		errExpected  bool
@@ -68,9 +68,9 @@ func TestTracingHooks(t *testing.T) {
 			errExpected: true,
 		},
 		{
-			desc:    "user error should be not reported as an erroneous span when correct option is set",
-			service: twirptest.ErroringHatmaker(twirp.NotFoundError("not found")),
-			hookOpts: []HookOpt{WithUserErr(false)},
+			desc:       "user error should be not reported as an erroneous span when correct option is set",
+			service:    twirptest.ErroringHatmaker(twirp.NotFoundError("not found")),
+			serverOpts: []TraceServerOption{IncludeClientErrors(false)},
 			expectedTags: map[string]interface{}{
 				"package":          "twirptest",
 				"component":        "twirp",
@@ -101,7 +101,7 @@ func TestTracingHooks(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			tracer := setupMockTracer()
-			hooks := NewOpenTracingHooks(tracer, tt.hookOpts...)
+			hooks := NewOpenTracingHooks(tracer, tt.serverOpts...)
 
 			server, client := serverAndClient(tt.service, hooks)
 			defer server.Close()

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -21,7 +21,7 @@ func TestTracingHooks(t *testing.T) {
 	tests := []struct {
 		desc         string
 		service      twirptest.Haberdasher
-		serverOpts   []TraceServerOption
+		traceOpts   []TraceOption
 		expectedTags map[string]interface{}
 		expectedLogs []mocktracer.MockLogRecord
 		errExpected  bool
@@ -70,7 +70,7 @@ func TestTracingHooks(t *testing.T) {
 		{
 			desc:       "user error should be not reported as an erroneous span when correct option is set",
 			service:    twirptest.ErroringHatmaker(twirp.NotFoundError("not found")),
-			serverOpts: []TraceServerOption{IncludeClientErrors(false)},
+			traceOpts: []TraceOption{IncludeClientErrors(false)},
 			expectedTags: map[string]interface{}{
 				"package":          "twirptest",
 				"component":        "twirp",
@@ -101,7 +101,7 @@ func TestTracingHooks(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			tracer := setupMockTracer()
-			hooks := NewOpenTracingHooks(tracer, tt.serverOpts...)
+			hooks := NewOpenTracingHooks(tracer, tt.traceOpts...)
 
 			server, client := serverAndClient(tt.service, hooks)
 			defer server.Close()


### PR DESCRIPTION
This change introduces two configuration options, one for the
server hooks, and one for the client, which configure whether
client-class errors (4xx) are recorded as "error: true" in the
span.

Often times, client errors are expected behavior from the
perspective of the service, and having them report as errors to
trace collectors can obfuscate real service issues.

This is implemented using a functional options paradigm with
var args, which maintains backwards compatibility. Current users
will see no change to behavior or method signatures when updating.