### PR TITLE
tracing: add WithContextTags() to define a set of tags based on ctx

### DIFF
--- a/tracing_test.go
+++ b/tracing_test.go
@@ -59,6 +59,28 @@ func TestTracingHooks(t *testing.T) {
 			expectedLogs: []mocktracer.MockLogRecord{},
 		},
 		{
+			desc:    "set tags and logs with context tags",
+			service: twirptest.NoopHatmaker(),
+			traceOpts: []TraceOption{
+				WithContextTags(func(ctx context.Context) []TraceTag {
+					return []TraceTag{
+						{"foo", "bar"},
+						{"city", "tokyo"},
+					}
+				}),
+			},
+			expectedTags: map[string]interface{}{
+				"package":          "twirptest",
+				"component":        "twirp",
+				"service":          "Haberdasher",
+				"span.kind":        serverType,
+				"http.status_code": int64(200),
+				"foo":              "bar",
+				"city":             "tokyo",
+			},
+			expectedLogs: []mocktracer.MockLogRecord{},
+		},
+		{
 			desc:    "set tags and logs with operation name for an errored request",
 			service: twirptest.ErroringHatmaker(errors.New("test")),
 			expectedTags: map[string]interface{}{


### PR DESCRIPTION
This adds a new option to define the tags to be set on the parent span
based on the ctx. Most of the time the `ctx` holds important values,
such as request ID's or source IP's that might be useful to set on the
span.